### PR TITLE
get a messageRef on toggleVote

### DIFF
--- a/js/mainController.js
+++ b/js/mainController.js
@@ -66,6 +66,7 @@ angular
       }
 
       $scope.toggleVote = function(key, votes) {
+        var messagesRef = firebaseService.getMessagesRef($scope.userId);
         if (!localStorage.getItem(key)) {
           messagesRef.child(key).update({
             votes: votes + 1,


### PR DESCRIPTION
toggleVote was relying on a closure around a messageRef declared during instantiation. A new user on a new board couldn't upvote an item until a page reload because $scope.userId was empty when the controller was created.