### PR TITLE
Adding Oxford comma to the Prime Directive

### DIFF
--- a/components/header.html
+++ b/components/header.html
@@ -6,7 +6,7 @@
           Prime Directive
           <span>
             <blockquote>
-                <p>Regardless of what we discover, we understand and truly believe that everyone did the best job they could, given what was known at the time, their skills and abilities, the resources available and the situation at hand</p>
+                <p>Regardless of what we discover, we understand and truly believe that everyone did the best job they could, given what was known at the time, their skills and abilities, the resources available, and the situation at hand</p>
                 <footer>In Project Retrospectives, Norm Kerth</footer>
             </blockquote>
           </span>


### PR DESCRIPTION
As seen on [Fun Retrospectives](http://www.funretrospectives.com/the-retrospective-prime-directive/), the Prime Directive contains an Oxford comma. This PR adds in the comma that was missing from the app.