### PR TITLE
[#182] Preventing submit for column name when field is empty

### DIFF
--- a/js/mainController.js
+++ b/js/mainController.js
@@ -164,6 +164,10 @@ angular
       };
 
       $scope.addNewColumn = function(name) {
+        if(typeof name === 'undefined' || name === '') {
+          return;
+        }
+
         $scope.board.columns.push({
           value: name,
           id: utils.getNextId($scope.board)
@@ -176,6 +180,10 @@ angular
       };
 
       $scope.changeColumnName = function(id, newName) {
+        if(typeof newName === 'undefined' || newName === '') {
+          return;
+        }
+
         $scope.board.columns.map(function(column, index, array) {
           if (column.id === id) {
             array[index].value = newName;

--- a/test/mainControllerTest.js
+++ b/test/mainControllerTest.js
@@ -327,12 +327,70 @@ describe('MainCtrl: ', function() {
       expect(closeAllSpy.called).to.be.true;
     });
 
+    it('should not add a new column to the board when name is empty', function() {
+      var expectedColumns = [
+        {
+          value: 'columnName',
+          id: 1
+        },
+        {
+          value: 'otherColumnName',
+          id: 2
+        }
+      ]
+
+      sinon.stub(utils, 'getNextId', function () { return 3; });
+
+      $scope.addNewColumn('');
+
+      expect($scope.board.columns).to.deep.equal(expectedColumns);
+      expect(setSpy.called).to.be.false;
+      expect(closeAllSpy.called).to.be.false;
+    });
+
+    it('should not add a new column to the board when name is undefined', function() {
+      var expectedColumns = [
+        {
+          value: 'columnName',
+          id: 1
+        },
+        {
+          value: 'otherColumnName',
+          id: 2
+        }
+      ]
+
+      sinon.stub(utils, 'getNextId', function () { return 3; });
+
+      $scope.addNewColumn(undefined);
+
+      expect($scope.board.columns).to.deep.equal(expectedColumns);
+      expect(setSpy.called).to.be.false;
+      expect(closeAllSpy.called).to.be.false;
+    });
+
     it('should change column name', function() {
       $scope.changeColumnName(1, 'new name!');
 
       expect($scope.board.columns[0].value).to.equal('new name!');
       expect(setSpy.called).to.be.true;
       expect(closeAllSpy.called).to.be.true;
+    });
+
+    it('should not change column name for empty string', function() {
+      $scope.changeColumnName(1, '');
+
+      expect($scope.board.columns[0].value).to.equal('columnName');
+      expect(setSpy.called).to.be.false;
+      expect(closeAllSpy.called).to.be.false;
+    });
+
+    it('should not change column name for undefined', function() {
+      $scope.changeColumnName(1, undefined);
+
+      expect($scope.board.columns[0].value).to.equal('columnName');
+      expect(setSpy.called).to.be.false;
+      expect(closeAllSpy.called).to.be.false;
     });
 
     it('should delete last column of the board', function() {


### PR DESCRIPTION
I added a simple check to return early when an undefined or empty string is submitted for both editing and creating new columns, along with a few unit tests to prove it works!