### PR TITLE
[#204] Generate CSV version of the board

### DIFF
--- a/components/sidebar.html
+++ b/components/sidebar.html
@@ -8,6 +8,7 @@
   <div class="sidebar-body">
     <button class="normal-button import-btn" ng-attr-data-clipboard-text="{{importExportService.getBoardPureText(board, messages, sortField)}}"><i class="fa fa-clipboard"></i>Copy board to clipboard</button>
     <button class="normal-button" ng-click="importExportService.generatePdf(board, messages, sortField)"><i class="fa fa-download"></i>Export board to PDF</button>
+    <button class="normal-button" ng-click="importExportService.generateCsv(board, messages, sortField)"><i class="fa fa-download"></i>Export board to CSV</button>
     <button class="normal-button" ng-click="modalService.openImportBoard(this)"><i class="fa fa-upload"></i>Import CSV</button>
     <button class="normal-button" ng-click="modalService.openVoteSettings(this)"><i class="fa fa-thumbs-up"></i>Vote settings</button>
     <button class="normal-button" ng-click="modalService.openCardSettings(this)"><i class="fa fa-sticky-note"></i>Private writing</button>

--- a/js/services/csvService.js
+++ b/js/services/csvService.js
@@ -1,0 +1,49 @@
+'use strict';
+
+angular
+  .module('fireideaz')
+  .service('CsvService', [function () {
+    var csvService = {};
+
+    var arrayExists = function(array) {
+      return array !== undefined;
+    };
+
+    var isEmptyCell = function(nextValue) {
+      return nextValue === undefined;
+    };
+
+    csvService.buildCsvText = function(doubleArray) {
+        var csvText ='';
+        
+        var longestColumn = csvService.determineLongestColumn(doubleArray);
+
+        // Going by row because CVS are ordered by rows
+        for(var rowIndex = 0; rowIndex < longestColumn; rowIndex++) {
+          for(var columnIndex = 0; columnIndex < longestColumn; columnIndex++) {
+            var column = doubleArray[columnIndex];
+            if(!arrayExists(column)) {
+              break;
+            }
+
+            var nextValue = column[rowIndex];
+            if(isEmptyCell(nextValue)) {
+              nextValue = '';
+            }
+            csvText += nextValue + ',';
+          }
+  
+          csvText += '\r\n';
+        }
+  
+        return csvText;
+      };
+
+      csvService.determineLongestColumn = function(doubleArray) {
+        return doubleArray.reduce(function(prev, next) {
+          return next.length > prev ? next.length: prev;
+        }, doubleArray.length);
+      };
+
+    return csvService;
+  }]);

--- a/js/services/importExportService.js
+++ b/js/services/importExportService.js
@@ -160,5 +160,73 @@ angular
       pdf.save(board.boardId + '.pdf');
     };
 
+    importExportService.generateCsv = function(board, messages, sortField) {
+
+      var longestColumn = 0;
+      var columns = board.columns.map(function(column, columnIndex) {
+        // Using index + 1 because column IDs start from 1
+        var columnMessages = $filter('filter')(messages, getColumnFieldObject(columnIndex + 1));
+        var sortedColumnMessages = $filter('orderBy')(columnMessages, importExportService.getSortFields(sortField));
+        
+        if(columnMessages.length > longestColumn) {
+          longestColumn = columnMessages.length;
+        }
+
+        var messagesText = sortedColumnMessages.map(function(message) { 
+          return message.text;
+        });
+
+        var columnArray = [column.value].concat(messagesText);
+
+        return columnArray;
+      });
+
+      var csvText = buildCsvText(columns, longestColumn);
+      showCsvFileDownload(csvText);
+    };
+
+    var getColumnFieldObject = function(columnId) {
+      return {
+        type: {
+          id: columnId
+        }
+      };
+    };
+
+    var buildCsvText = function(columnsArray, longestColumn) {
+      var csvText ='';
+      
+      // Going by row because CVS are ordered by rows
+      for(var rowIndex = 0; rowIndex <= longestColumn; rowIndex++) {
+        for(var columnIndex = 0; columnIndex < columnsArray.length; columnIndex++) {
+        
+          var nextValue = columnsArray[columnIndex][rowIndex];
+          if(isEmptyCell(nextValue)) {
+            nextValue = '';
+          }
+          csvText += nextValue + ',';
+        }
+
+        csvText += '\r\n';
+      }
+
+      return csvText;
+    };
+
+    var isEmptyCell = function(nextValue) {
+      return nextValue === undefined;
+    };
+
+    var showCsvFileDownload = function(csvText) {
+      var blob = new Blob([csvText]);
+      var downloadLink = document.createElement('a');
+      downloadLink.href = window.URL.createObjectURL(blob, {type: 'text/csv'});
+      downloadLink.download = 'data.csv';
+      
+      document.body.appendChild(downloadLink);
+      downloadLink.click();
+      document.body.removeChild(downloadLink);
+    };
+
     return importExportService;
   }]);

--- a/test/csvServiceTest.js
+++ b/test/csvServiceTest.js
@@ -1,0 +1,77 @@
+describe('CsvService: ', function() {
+  var $rootScope, 
+      $scope, 
+      csvService;
+
+  var square = [
+    [1, 2],
+    [3, 4]
+  ];
+
+  var fewColumnsManyRows = [
+    [1, 2, 3, 4],
+    [5, 6]
+  ];
+
+  var fewRowsManyColumns = [
+    [1, 2],
+    [3, 4],
+    [5],
+    [6]
+  ];
+
+  beforeEach(angular.mock.module('fireideaz'));
+
+  beforeEach(inject(function($injector){
+
+    $rootScope = $injector.get('$rootScope');
+    $scope = $rootScope.$new();
+    inject(function($injector) {
+      csvService = $injector.get('CsvService');
+    });
+  }));
+  
+  describe('BuildCsvText', function() {
+    it('should output a comma and a new line when empty', function() {
+      var csvText = csvService.buildCsvText([[]]);
+      expect(csvText).to.equal(',\r\n');
+    });
+
+    it('should output valid csv when there are no cards and only one column', function() {
+      var csvText = csvService.buildCsvText([[1]]);
+      expect(csvText).to.equal('1,\r\n');
+    });
+
+    it('should outputs correct csv for a square grid', function() {
+      var csvText = csvService.buildCsvText(square);
+      expect(csvText).to.equal('1,3,\r\n2,4,\r\n');
+    });
+
+    it('should return square board when grid is few columns and many rows', function() {
+      var csvText = csvService.buildCsvText(fewColumnsManyRows);
+      expect(csvText).to.equal('1,5,\r\n2,6,\r\n3,,\r\n4,,\r\n');
+    });
+
+    it('should return square board when grid is few rows and many columns', function() {
+      var csvText = csvService.buildCsvText(fewRowsManyColumns);
+      expect(csvText).to.equal('1,3,5,6,\r\n2,4,,,\r\n,,,,\r\n,,,,\r\n');
+    });
+  });
+
+  describe('DetermineLongestLength', function() {
+    it('should find the highest length for a square', function() {
+        var longestLength = csvService.determineLongestColumn(square);
+        expect(longestLength).to.equal(2);
+      });
+
+    it('should find the highest length for few columns and many rows', function() {
+      var longestLength = csvService.determineLongestColumn(fewColumnsManyRows);
+      expect(longestLength).to.equal(4);
+    });
+
+    it('should find the highest length for few rows and many columns', function() {
+      var longestLength = csvService.determineLongestColumn(fewRowsManyColumns);
+      expect(longestLength).to.equal(4);
+    });
+  });
+});


### PR DESCRIPTION
This PR downloads a CSV version of the board. I've tested it on the latest version of Edge, Chrome, and Firefox and the download pops up on all of them!

A few potential issues for the review:

- This PR currently fails a few JS Hint rules about using something before it is defined. I'm leaving it the way it is and will re-check the warnings once we move to ESLint. If that PR won't be finished anytime soon, I can fix the JS Hint errors so we can merge. **The TravisCI build will fail until then.**
- I was unable to add unit tests, since the function I created doesn't return anything for me to check. I could make some of the private functions I added public and test those, but I'm not sure which way would be preferred.
- I'm using .map() in a few places instead of jQuery, in hopes that the project is slowly migrating to newer syntaxes. If you want it in jQuery still, let me know and I'll revert it.