### PR TITLE
[#204] Added CSV character encoding and made download name the board name

### DIFF
--- a/js/services/csvService.js
+++ b/js/services/csvService.js
@@ -15,11 +15,11 @@ angular
 
     var isString = function(stringValue) {
       return typeof stringValue === 'string' || stringValue instanceof String;
-    }
+    };
 
     var endodeForCsv = function(stringToEncode) {
       // Enocde " characters
-      var stringToEncode = stringToEncode.replace(/"/g, '""');
+      stringToEncode = stringToEncode.replace(/"/g, '""');
 
       // Surround string with " characters if " , or \n are present
       if (stringToEncode.search(/("|,|\n)/g) >= 0) {

--- a/js/services/csvService.js
+++ b/js/services/csvService.js
@@ -13,6 +13,22 @@ angular
       return nextValue === undefined;
     };
 
+    var isString = function(stringValue) {
+      return typeof stringValue === 'string' || stringValue instanceof String;
+    }
+
+    var endodeForCsv = function(stringToEncode) {
+      // Enocde " characters
+      var stringToEncode = stringToEncode.replace(/"/g, '""');
+
+      // Surround string with " characters if " , or \n are present
+      if (stringToEncode.search(/("|,|\n)/g) >= 0) {
+        stringToEncode = '"' + stringToEncode + '"';
+      }
+
+      return stringToEncode;
+    };
+
     csvService.buildCsvText = function(doubleArray) {
         var csvText ='';
         
@@ -30,6 +46,11 @@ angular
             if(isEmptyCell(nextValue)) {
               nextValue = '';
             }
+
+            if(isString(nextValue)) {
+              nextValue = endodeForCsv(nextValue);
+            }
+
             csvText += nextValue + ',';
           }
   

--- a/js/services/importExportService.js
+++ b/js/services/importExportService.js
@@ -170,11 +170,11 @@ angular
       };
     };
 
-    var showCsvFileDownload = function(csvText) {
+    var showCsvFileDownload = function(csvText, fileName) {
       var blob = new Blob([csvText]);
       var downloadLink = document.createElement('a');
       downloadLink.href = window.URL.createObjectURL(blob, {type: 'text/csv'});
-      downloadLink.download = 'data.csv';
+      downloadLink.download = fileName;
       
       document.body.appendChild(downloadLink);
       downloadLink.click();
@@ -198,7 +198,7 @@ angular
       });
 
       var csvText = CsvService.buildCsvText(columns);
-      showCsvFileDownload(csvText);
+      showCsvFileDownload(csvText, board.boardId + '.csv');
     };
 
     return importExportService;

--- a/test/csvServiceTest.js
+++ b/test/csvServiceTest.js
@@ -20,6 +20,10 @@ describe('CsvService: ', function() {
     [6]
   ];
 
+  var specialCharacters = [
+    ['"Quotes"', 'Wait, a comma?', 'Newline\nCinema', '"Hey",\nall together']
+  ];
+
   beforeEach(angular.mock.module('fireideaz'));
 
   beforeEach(inject(function($injector){
@@ -55,6 +59,11 @@ describe('CsvService: ', function() {
     it('should return square board when grid is few rows and many columns', function() {
       var csvText = csvService.buildCsvText(fewRowsManyColumns);
       expect(csvText).to.equal('1,3,5,6,\r\n2,4,,,\r\n,,,,\r\n,,,,\r\n');
+    });
+
+    it('should encode special characters', function() {
+      var csvText = csvService.buildCsvText(specialCharacters);
+      expect(csvText).to.equal('"""Quotes""",\r\n"Wait, a comma?",\r\n"Newline\nCinema",\r\n"""Hey"",\nall together",\r\n');
     });
   });
 


### PR DESCRIPTION
Today during my team's retrospective, we noticed that if there is a comma in any of the cards, the CSV export I wrote would break 😢 

This PR fixes the issue by encoding all the special characters for CSV, which are the `",\n` characters. I've added a test that checks that each special character is encoded correctly.

I also made it so the suggested file name is the name of the board.