### PR TITLE
[WIP] Tidy formatting on main page

### DIFF
--- a/components/mainPage.html
+++ b/components/mainPage.html
@@ -15,14 +15,14 @@
             <legend>Email Subscription</legend>
             <h2>Wanna be notified of updates?</h2>
             <input type="email" value="" name="EMAIL" placeholder="Enter your email address" class="subscribe__email" id="mce-EMAIL" novalidate aria-label="Email address" />
-	          <input type="submit" title="email submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe">
+            <input type="submit" title="email submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe">
           </fieldset>
           <div id="mce-responses" class="clear">
             <div class="response" id="mce-error-response" style="display:none"></div>
             <div class="response" id="mce-success-response" style="display:none"></div>
           </div>
           <div style="position: absolute; left: -5000px;" aria-hidden="true">
-	          <input title="paypal pixel" type="text" name="b_a1df66d58e9447064d73bf0bc_405856384a" tabindex="-1" value="">
+            <input title="paypal pixel" type="text" name="b_a1df66d58e9447064d73bf0bc_405856384a" tabindex="-1" value="">
           </div>
         </div>
       </form>
@@ -37,15 +37,15 @@
     <h2>Set the context</h2>
     <img src="img/image1.png" alt="screenshot of set the context feature" />
     <p>
-  Why is this retrospective being held? What will it cover? Retrospectives, similarly to any other meeting, are more effective if the participants align their expectations before getting into it.
+      Why is this retrospective being held? What will it cover? Retrospectives, similarly to any other meeting, are more effective if the participants align their expectations before getting into it.
     </p>
   </section>
   <section class="step">
     <h2>
       Read the prime directive
     </h2>
-  <img src="img/image2.png" alt="screenshot of read the prime directive feature" />
-  <p class="left">The statement is invaluable for setting the meeting tone. Make it visible to all participants, and read it out loud before running your retrospective activity.</p>
+    <img src="img/image2.png" alt="screenshot of read the prime directive feature" />
+    <p>The statement is invaluable for setting the meeting tone. Make it visible to all participants, and read it out loud before running your retrospective activity.</p>
   </section>
   <section class="step">
     <h2>
@@ -53,7 +53,7 @@
     </h2>
     <img src="img/image3.png" alt="screenshot of an example of a board" />
     <p>
-  It is time to gather data, talk about the positive stuff, recognize people and seek improvements. Select an activity, create and customize your board. Go for it!
+      It is time to gather data, talk about the positive stuff, recognize people and seek improvements. Select an activity, create and customize your board. Go for it!
     </p>
   </section>
   <section>


### PR DESCRIPTION
I didn't find this in the issues - hope it's useful anyway, it's a very minor html tidy up of a few things I noticed when browsing funretro.

Removed a `class=left` on one of the paragraphs inside a `step` section to make it consistent with the other `step`s.

Tidied up some formatting - made spacing more consistent at two spaces and removed some tabs.