### PR TITLE
Disable eslint warning for angular filenames

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,7 +23,7 @@ module.exports = {
   rules: {
     'angular/di': ['warn', '$inject'],
     'angular/controller-as': ['warn'],
-    'angular/file-name': ['warn'],
+    'angular/file-name': [0],
     'angular/no-service-method': ['warn'],
     'no-unused-expressions': [0],
     semi: [2, 'always'],


### PR DESCRIPTION
Gets rid of a warning that says file names must match service name.

![image](https://user-images.githubusercontent.com/784889/47277825-a7095a80-d578-11e8-823e-f4b43fc1378d.png)
